### PR TITLE
4단계 - ControllerAdvice, ExceptionHandler 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ idea {
 
 version = '1.0.0'
 sourceCompatibility = 1.8
+buildDir("webapp/WEB-INF/classes")
 
 repositories {
     mavenCentral()

--- a/note.md
+++ b/note.md
@@ -1,5 +1,19 @@
 # Aspect OP
 
+## 4단계 - ControllerAdvice, ExceptionHandler 구현
+
+하.. 또 Hard reset 해버림..  
+생각보다 쉬울거라고 생각했는데 멍청하게 하는 바람에 또 망함 ^ㅅ^  
+
+1. 처음엔 Dispatcher 서블릿에서 처리했다.  
+2. 핸들러에서 익셉션이 발생한다.  
+3. InvocationTargetException이 발생한다.  
+4. 망한 파트 - (읭.. 그럼 HandlerExecution에서 처리해볼까)
+5. hard reset ^ㅅ^
+
+덕분에 InvocationTargetException가 발생했을 땐 getCause해야 root cause가 나온다는 사실을 알게됨.  
+그래도 그나마 나은건 저번처럼 갈아 엎는 수준은 아니고 stash 해둔 것들 쓰면 해결될 듯..
+
 ## 3단계 - Transaction AOP 구현
 
 별로 어렵진 않을 거 같은데 책임을 어디에 위치시키느냐가 약간 고민.  

--- a/src/main/java/core/annotation/web/ControllerAdvice.java
+++ b/src/main/java/core/annotation/web/ControllerAdvice.java
@@ -1,0 +1,11 @@
+package core.annotation.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ControllerAdvice {
+}

--- a/src/main/java/core/annotation/web/ExceptionHandler.java
+++ b/src/main/java/core/annotation/web/ExceptionHandler.java
@@ -1,0 +1,12 @@
+package core.annotation.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExceptionHandler {
+    Class<? extends Throwable>[] value() default {};
+}

--- a/src/main/java/core/di/context/annotation/ClasspathBeanDefinitionScanner.java
+++ b/src/main/java/core/di/context/annotation/ClasspathBeanDefinitionScanner.java
@@ -4,6 +4,7 @@ import core.annotation.Component;
 import core.annotation.Repository;
 import core.annotation.Service;
 import core.annotation.web.Controller;
+import core.annotation.web.ControllerAdvice;
 import core.di.beans.factory.support.BeanDefinitionRegistry;
 import core.di.beans.factory.support.DefaultBeanDefinition;
 import org.reflections.Reflections;
@@ -21,7 +22,7 @@ public final class ClasspathBeanDefinitionScanner extends AbstractBeanDefinition
     public void doScan(Object... basePackages) {
         final Reflections reflections = new Reflections(basePackages);
         final Set<Class<?>> beanClasses = getTypesAnnotatedWith(reflections, Controller.class, Service.class,
-                Repository.class, Component.class);
+                Repository.class, Component.class, ControllerAdvice.class);
         for (Class<?> clazz : beanClasses) {
             beanDefinitionRegistry.registerBeanDefinition(clazz, new DefaultBeanDefinition(clazz));
         }

--- a/src/main/java/core/mvc/DispatcherServlet.java
+++ b/src/main/java/core/mvc/DispatcherServlet.java
@@ -45,7 +45,7 @@ public class DispatcherServlet extends HttpServlet {
             ModelAndView mav = handlerExecutor.handle(req, resp, maybeHandler.get());
             render(mav, req, resp);
         } catch (Throwable e) {
-            logger.error("Exception : {}", e);
+            logger.error("Exception : {}", e.getCause().getClass());
             throw new ServletException(e.getMessage());
         }
     }

--- a/src/main/java/core/mvc/DispatcherServlet.java
+++ b/src/main/java/core/mvc/DispatcherServlet.java
@@ -52,7 +52,7 @@ public class DispatcherServlet extends HttpServlet {
             ModelAndView mav = handlerExecutor.handle(req, resp, maybeHandler.get());
             render(mav, req, resp);
         } catch (Throwable e) {
-            logger.error("Exception : {}", e.getCause().getClass());
+            logger.error("Exception : {}", e.getCause());
             handleException(e, req, resp);
         }
     }
@@ -63,7 +63,7 @@ public class DispatcherServlet extends HttpServlet {
     }
 
     private void handleException(Throwable t, HttpServletRequest req, HttpServletResponse resp) throws ServletException {
-        final ExceptionHandlerExecution handler = exceptionHandlerMapping.getHandler(t.getCause());
+        final ExceptionHandlerExecution handler = exceptionHandlerMapping.getHandler(t);
         if (handler == null) {
             throw new ServletException(t.getMessage());
         }

--- a/src/main/java/core/mvc/ExceptionHandlerMapping.java
+++ b/src/main/java/core/mvc/ExceptionHandlerMapping.java
@@ -1,0 +1,62 @@
+package core.mvc;
+
+import com.google.common.collect.Maps;
+import core.annotation.web.ControllerAdvice;
+import core.annotation.web.ExceptionHandler;
+import core.di.context.ApplicationContext;
+import core.mvc.tobe.ExceptionHandlerExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class ExceptionHandlerMapping implements HandlerMapping<Throwable> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExceptionHandlerMapping.class);
+
+    private final ApplicationContext applicationContext;
+    private final Map<Class<? extends Throwable>, ExceptionHandlerExecution> handlerExecutions = Maps.newHashMap();
+
+    public ExceptionHandlerMapping(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void initialize() {
+        final Map<Class<?>, Object> controllerAdvice = getControllerAdvice(applicationContext);
+        for (Map.Entry<Class<?>, Object> entry : controllerAdvice.entrySet()) {
+            registerExceptionHandlerExecutions(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public ExceptionHandlerExecution getHandler(Throwable type) {
+        return handlerExecutions.get(type.getClass());
+    }
+
+    private Map<Class<?>, Object> getControllerAdvice(ApplicationContext ac) {
+        final Map<Class<?>, Object> advice = Maps.newHashMap();
+        ac.getBeanClasses().stream()
+                .filter(clazz -> clazz.isAnnotationPresent(ControllerAdvice.class))
+                .forEach(adviceClass -> advice.put(adviceClass, ac.getBean(adviceClass)));
+        return advice;
+    }
+
+    private void registerExceptionHandlerExecutions(Class<?> clazz, Object bean) {
+        for (Method method : clazz.getMethods()) {
+            final ExceptionHandler handler = method.getAnnotation(ExceptionHandler.class);
+            if (handler != null) {
+                register(bean, method, handler);
+            }
+        }
+    }
+
+    private void register(Object bean, Method method, ExceptionHandler handler) {
+        final Class<? extends Throwable>[] types = handler.value();
+        final ExceptionHandlerExecution exceptionHandler = new ExceptionHandlerExecution(bean, method);
+        for (Class<? extends Throwable> type : types) {
+            handlerExecutions.put(type, exceptionHandler);
+        }
+    }
+}

--- a/src/main/java/core/mvc/HandlerMapping.java
+++ b/src/main/java/core/mvc/HandlerMapping.java
@@ -1,9 +1,7 @@
 package core.mvc;
 
-import javax.servlet.http.HttpServletRequest;
-
-public interface HandlerMapping {
+public interface HandlerMapping<T> {
     void initialize();
 
-    Object getHandler(HttpServletRequest request);
+    Object getHandler(T type);
 }

--- a/src/main/java/core/mvc/advice/RequiredLoginAdvice.java
+++ b/src/main/java/core/mvc/advice/RequiredLoginAdvice.java
@@ -1,0 +1,15 @@
+package core.mvc.advice;
+
+import core.annotation.web.ControllerAdvice;
+import core.annotation.web.ExceptionHandler;
+import core.mvc.JspView;
+import core.mvc.ModelAndView;
+import next.security.RequiredLoginException;
+
+@ControllerAdvice
+public class RequiredLoginAdvice {
+    @ExceptionHandler(RequiredLoginException.class)
+    public ModelAndView loginRequired() {
+        return new ModelAndView(new JspView("redirect:/users/loginForm"));
+    }
+}

--- a/src/main/java/core/mvc/asis/RequestMapping.java
+++ b/src/main/java/core/mvc/asis/RequestMapping.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 
-public class RequestMapping implements HandlerMapping {
+public class RequestMapping implements HandlerMapping<HttpServletRequest> {
     private static final Logger logger = LoggerFactory.getLogger(DispatcherServlet.class);
     private Map<String, Controller> mappings = new HashMap<>();
 
@@ -20,6 +20,7 @@ public class RequestMapping implements HandlerMapping {
         });
     }
 
+    @Override
     public Controller getHandler(HttpServletRequest request) {
         return mappings.get(request.getRequestURI());
     }

--- a/src/main/java/core/mvc/tobe/AnnotationHandlerMapping.java
+++ b/src/main/java/core/mvc/tobe/AnnotationHandlerMapping.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
-public class AnnotationHandlerMapping implements HandlerMapping {
+public class AnnotationHandlerMapping implements HandlerMapping<HttpServletRequest> {
     private static final Logger logger = LoggerFactory.getLogger(AnnotationHandlerMapping.class);
 
     private ApplicationContext applicationContext;

--- a/src/main/java/core/mvc/tobe/ExceptionHandlerExecution.java
+++ b/src/main/java/core/mvc/tobe/ExceptionHandlerExecution.java
@@ -1,0 +1,19 @@
+package core.mvc.tobe;
+
+import core.mvc.ModelAndView;
+
+import java.lang.reflect.Method;
+
+public class ExceptionHandlerExecution {
+    private final Object target;
+    private final Method method;
+
+    public ExceptionHandlerExecution(Object target, Method method) {
+        this.target = target;
+        this.method = method;
+    }
+
+    public ModelAndView handle() throws Exception {
+        return (ModelAndView) method.invoke(target);
+    }
+}

--- a/src/main/java/next/config/MyWebApplicationInitializer.java
+++ b/src/main/java/next/config/MyWebApplicationInitializer.java
@@ -3,6 +3,7 @@ package next.config;
 import core.di.context.ApplicationContext;
 import core.di.context.support.AnnotationConfigApplicationContext;
 import core.mvc.DispatcherServlet;
+import core.mvc.ExceptionHandlerMapping;
 import core.mvc.asis.ControllerHandlerAdapter;
 import core.mvc.asis.RequestMapping;
 import core.mvc.tobe.AnnotationHandlerMapping;
@@ -26,11 +27,15 @@ public class MyWebApplicationInitializer implements WebApplicationInitializer {
         AnnotationHandlerMapping ahm = new AnnotationHandlerMapping(ac, handlerConverter);
         ahm.initialize();
 
+        final ExceptionHandlerMapping ehm = new ExceptionHandlerMapping(ac);
+        ehm.initialize();
+
         DispatcherServlet dispatcherServlet = new DispatcherServlet();
         dispatcherServlet.addHandlerMapping(ahm);
         dispatcherServlet.addHandlerMapping(new RequestMapping());
         dispatcherServlet.addHandlerAdapter(new HandlerExecutionHandlerAdapter());
         dispatcherServlet.addHandlerAdapter(new ControllerHandlerAdapter());
+        dispatcherServlet.addExceptionHandlerMapping(ehm);
 
         ServletRegistration.Dynamic dispatcher = servletContext.addServlet("dispatcher", dispatcherServlet);
         dispatcher.setLoadOnStartup(1);

--- a/src/test/java/core/mvc/ExceptionHandlerMappingTest.java
+++ b/src/test/java/core/mvc/ExceptionHandlerMappingTest.java
@@ -10,6 +10,9 @@ import core.mvc.tobe.AnnotationHandlerMapping;
 import core.mvc.tobe.HandlerConverter;
 import core.mvc.tobe.HandlerExecutionHandlerAdapter;
 import next.config.MyConfiguration;
+import next.model.User;
+import next.security.LoginUser;
+import next.security.RequiredLoginException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,10 +65,7 @@ public class ExceptionHandlerMappingTest {
         }
 
         @RequestMapping(value = "/api/exception", method = RequestMethod.GET)
-        public ModelAndView exception(@PathVariable String test) throws Exception {
-            if (System.currentTimeMillis() > 0) {
-                throw new NoReasonException();
-            }
+        public ModelAndView exception(@LoginUser User loginUser) throws Exception {
             return jspView("redirect:/abc");
         }
     }
@@ -75,16 +75,9 @@ public class ExceptionHandlerMappingTest {
         public DummyControllerAdvice() {
         }
 
-        @ExceptionHandler(NoReasonException.class)
-        public ModelAndView noReasonException() {
+        @ExceptionHandler(RequiredLoginException.class)
+        public ModelAndView requiredLoginExceptionHandler() {
             return new ModelAndView(new JspView("redirect:/"));
         }
     }
-
-    public static class NoReasonException extends Exception {
-        public NoReasonException() {
-            super();
-        }
-    }
-
 }

--- a/src/test/java/core/mvc/ExceptionHandlerMappingTest.java
+++ b/src/test/java/core/mvc/ExceptionHandlerMappingTest.java
@@ -1,0 +1,90 @@
+package core.mvc;
+
+import core.annotation.Configuration;
+import core.annotation.web.*;
+import core.di.context.ApplicationContext;
+import core.di.context.support.AnnotationConfigApplicationContext;
+import core.mvc.asis.ControllerHandlerAdapter;
+import core.mvc.tobe.AbstractNewController;
+import core.mvc.tobe.AnnotationHandlerMapping;
+import core.mvc.tobe.HandlerConverter;
+import core.mvc.tobe.HandlerExecutionHandlerAdapter;
+import next.config.MyConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Configuration
+public class ExceptionHandlerMappingTest {
+
+    private DispatcherServlet dispatcher;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(this.getClass(), MyConfiguration.class);
+        AnnotationHandlerMapping ahm = new AnnotationHandlerMapping(ac, ac.getBean(HandlerConverter.class));
+        ahm.initialize();
+
+        final ExceptionHandlerMapping ehm = new ExceptionHandlerMapping(ac);
+        ehm.initialize();
+
+        dispatcher = new DispatcherServlet();
+        dispatcher.addHandlerMapping(ahm);
+        dispatcher.addHandlerMapping(new core.mvc.asis.RequestMapping());
+        dispatcher.addHandlerAdapter(new HandlerExecutionHandlerAdapter());
+        dispatcher.addHandlerAdapter(new ControllerHandlerAdapter());
+        dispatcher.addExceptionHandlerMapping(ehm);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @DisplayName("익셉션 핸들러 동작 테스트")
+    @Test
+    void exception_handler() throws Exception {
+        request.setRequestURI("/api/exception");
+        request.setMethod("GET");
+
+        dispatcher.service(request, response);
+        final String redirectedUrl = response.getRedirectedUrl();
+        assertThat(redirectedUrl).isEqualTo("/");
+    }
+
+    @Controller
+    public static class DummyController extends AbstractNewController {
+        public DummyController() {
+        }
+
+        @RequestMapping(value = "/api/exception", method = RequestMethod.GET)
+        public ModelAndView exception(@PathVariable String test) throws Exception {
+            if (System.currentTimeMillis() > 0) {
+                throw new NoReasonException();
+            }
+            return jspView("redirect:/abc");
+        }
+    }
+
+    @ControllerAdvice
+    public static class DummyControllerAdvice {
+        public DummyControllerAdvice() {
+        }
+
+        @ExceptionHandler(NoReasonException.class)
+        public ModelAndView noReasonException() {
+            return new ModelAndView(new JspView("redirect:/"));
+        }
+    }
+
+    public static class NoReasonException extends Exception {
+        public NoReasonException() {
+            super();
+        }
+    }
+
+}


### PR DESCRIPTION
안녕하세요 리뷰어님! 마지막 단계에 도착했네요.
이번에는 엉뚱한 삽질 때문에 리셋하고 재조립을 했어요.. =_=;

지난번 피드백에 대한 질문인데요..!

> 만약 @Service 과 @Transactional 을 모두 가진 클래스가 존재한다면 2가지 스캐너에서 모두 스캔이 되고 빈 정의도 2개가 생성 되겠네요. (타입이 Key 이므로 덮어쓸 듯 합니다.)

위와 같이 피드백을 해주셨는데, 실제로 `BeanDefinition`의 키가 `class`이기 때문에 `@Service`가 먼저 스캔되더라도 `@Transactional`이 있으면 이에 대한 bean은 하나만 생성됩니다. 이것 때문에 스캔 순서를 ClassPath -> Transactional로 해둔 것입니다.. 더 세련된 방법이 있을 것 같지만 과해지는 것 같아 이렇게 해두었어요..!

다만 오히려 Transactional에 특화된 Advice와 Pointcut의 ProxyFactoryBean을 생성하는 것에 대한 의문이 생겼어요. 제 의도는 `TransactionalProxyBeanDefinitionScanner`가 Transactional만을 위한 스캐너인데, `ClasspathBeanDefinitionScanner`에서도 DefaultBeanDefinition에 대한 생성을 담당하고 있어서 저도 이 맥락에 맞추어 이렇게 만들었어요. 뭐라 설명할 수는 없지만 약간 어색하다는 생각이 들어요. (새벽이라서 그럴수도 있어요...!)

질문이 참 두서 없는데요.. 흑흑 정리하자면

1. TransactionalProxyBeanDefinitionScanner가 Transactional에 특화된 ProxyFactoryBean을 생성하는 것이 어색하다는 느낌을 받았는데 그 이유를 모르겠어요..!

입니다.

오늘도 리뷰 감사합니다...! 